### PR TITLE
Update theme colour

### DIFF
--- a/src/build/template.html
+++ b/src/build/template.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset='utf-8' >
   <meta name="viewport" content="width=device-width">
-  <meta id='theThemeColor' name='theme-color' content='#4169e1' >
+  <meta id='theThemeColor' name='theme-color' content='#6248CA' >
   <meta name="description" content="{intl.appDescription}" >
 
   %sapper.base%


### PR DESCRIPTION
It seems the theme colour (which is shown in the Android status bar) is still showing the Pinafore colour. I guess this doesn't get used by iOS? I think this is the correct one.